### PR TITLE
Updated tutorial documentation notes

### DIFF
--- a/application/start/add-your-first-endpoint.md
+++ b/application/start/add-your-first-endpoint.md
@@ -126,20 +126,18 @@ description: >-
      }
     ```
 
-6. Export environment variable to allow for go testing with Substrate. Run the command below 
-    ```bash
+6. Export environment variable to allow for go testing with ```go test```. Run the command below and copy the export statement from the output. The path will be different for every user so make sure you are copying your specific export statement and **NOT** the tutorials export statement below.
+    ```
     $ make print-export-path
-    ```
-    Copy the export statement from the output and execute in the terminal. The path will be different for every user, so make sure you are not copying and pasting the tutorials export statement.
-    ```
     echo "export SUBSTRATEHCP_FILE=/Users/craigpeoples/Repositories/sandbox/./build/substratehcp-darwin-amd64-2.170.0-fabric2"
     export SUBSTRATEHCP_FILE=/Users/craigpeoples/Repositories/sandbox/./build/substratehcp-darwin-amd64-2.170.0-fabric2
     ```
+    Paste the export statement in your terminal and execute it. This sets the new environment variable with the path to your substratehcp build.
     ```
     $ export SUBSTRATEHCP_FILE=/Users/craigpeoples/Repositories/sandbox/./build/substratehcp-darwin-amd64-2.170.0-fabric2
     ```
-    > _NOTE_: This variable needs to be exported for every shell session you want to execute go test
-    
+    > _NOTE_: This environment variable needs to be exported for every shell session you want to execute `go test`
+
 7.  Run the functional tests and confirm that it fails:
 
     ```

--- a/application/start/add-your-first-endpoint.md
+++ b/application/start/add-your-first-endpoint.md
@@ -126,8 +126,21 @@ description: >-
      }
     ```
 
-
-6.  Run the functional tests and confirm that it fails:
+6. Export environment variable to allow for go testing with Substrate. Run the command below 
+    ```bash
+    $ make print-export-path
+    ```
+    Copy the export statement from the output and execute in the terminal. The path will be different for every user, so make sure you are not copying and pasting the tutorials export statement.
+    ```
+    echo "export SUBSTRATEHCP_FILE=/Users/craigpeoples/Repositories/sandbox/./build/substratehcp-darwin-amd64-2.170.0-fabric2"
+    export SUBSTRATEHCP_FILE=/Users/craigpeoples/Repositories/sandbox/./build/substratehcp-darwin-amd64-2.170.0-fabric2
+    ```
+    ```
+    $ export SUBSTRATEHCP_FILE=/Users/craigpeoples/Repositories/sandbox/./build/substratehcp-darwin-amd64-2.170.0-fabric2
+    ```
+    > _NOTE_: This variable needs to be exported for every shell session you want to execute go test
+    
+7.  Run the functional tests and confirm that it fails:
 
     ```
     $ make api
@@ -142,6 +155,7 @@ description: >-
     ```
 
     > _NOTE_: `$(make host-go-env)` sets env in your local shell. It only needs to be called once per shell session.
+
 
 
 

--- a/application/start/update-your-data-model.md
+++ b/application/start/update-your-data-model.md
@@ -35,7 +35,7 @@ description: >-
     field.
 
     ```
-    $ make tests-martin
+    $ make test-docker
     ❏ Sandbox Example:  Managing Account Balances
     ↳ Create Account 1
       POST http://sandbox_oracle:8080/v1/accounts/abc-7ebd3108-ce4c-4667-abc9-9f69c5d4c3ad [400 Bad Request, 400B, 6ms]
@@ -79,7 +79,7 @@ description: >-
 
     ```bash
     $ make mem-down mem-up
-    $ make tests-martin
+    $ make test-docker
     Output:
     ┌─────────────────────────┬───────────────────┬───────────────────┐
     │                         │          executed │            failed │
@@ -119,7 +119,7 @@ description: >-
 8.  Confirm the new test fails:
 
     ```bash
-    $ make tests-martin
+    $ make test-docker
     Output:
       #  failure           detail
 


### PR DESCRIPTION
- Updated docs to handle 2 errors in the tutorial - getting started.
- Replaced make target `tests-martin` with make target `test-docker` to run api test
- Added documentation for how to export the substrate hcp file path environment variable for go testing